### PR TITLE
Don't consume Spools in creative

### DIFF
--- a/src/main/java/deboni/potatologistics/items/ItemWireSpool.java
+++ b/src/main/java/deboni/potatologistics/items/ItemWireSpool.java
@@ -35,7 +35,7 @@ public class ItemWireSpool extends Item {
                     int z = itemstack.getData().getInteger("z");
                     boolean connectedSuccessfully = ((TileEntityEnergyConnector) te).addConnection(x, y, z);
                     if (connectedSuccessfully) {
-                        itemstack.stackSize--;
+                        itemstack.consumeItem(entityplayer);
                     }
                     itemstack.setCustomName(this.displayName);
                 }


### PR DESCRIPTION
Using the standard itemstack.consumeItem(player) since it accounts for gamemode